### PR TITLE
updated config tests and isValidReq

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,8 +13,11 @@ module.exports = {
         isValidReq: function (expect, has) {
             for (var property in expect) {
                 // (property exists in expect) and [(exists in has and is null/empty) or (does not exists in has)]
-                if (expect.hasOwnProperty(property) && ((has.hasOwnProperty(property) && (has[property] == null
-                    || has[property] == "")) || !has.hasOwnProperty(property))){
+                if (expect.hasOwnProperty(property) && 
+				((Object.prototype.hasOwnProperty.call(has,property) 
+				&& (has[property] == null 
+				|| has[property] == "")) 
+				|| !Object.prototype.hasOwnProperty.call(has,property))){
                     return false;
                 }
             }
@@ -33,7 +36,6 @@ module.exports = {
         use: true
     },
     
-    // should move db values to it's own config. 
     // dbLogin is just our database login credentials for c9 and AWS
     dbLogin: {
         c9: {
@@ -61,12 +63,21 @@ module.exports = {
         local: {
             connectionLimit: 10,
             host: 'localhost',
+            user: 'rachelle',
+            database: 'c9',
+            multipleStatements: true
+        }
+        /*
+        local: {
+            connectionLimit: 10,
+            host: 'localhost',
             port: '8889',
             user: 'zach',
             password: 'H5qsadBGTuuXyJGG',
             database: 'cs290',
             multipleStatements: true
         }
+        */
     },
 
     mapKey: "AIzaSyAmfNdzvBzM5eUew6Y3C1b5lfyljjSKFuE",

--- a/test/scripts/test_config.js
+++ b/test/scripts/test_config.js
@@ -8,10 +8,10 @@ describe('isValidReq Test', function () {
             a: "",
             b: ""
         };
-        var has = {
-            a: null,
-            b: "has"
-        };
+        var has = Object.create(null);
+        has.a = null;
+        has.b = "has";
+        
         assert(valreq(expects, has) == false);
         has.a = 'has';
         assert(valreq(expects, has));


### PR DESCRIPTION
isValidReq was sometimes throwing an error "hasOwnProperty is not a function"  

I found the solution which is explained in this post.  

http://stackoverflow.com/questions/32878954/object-javascipt-dont-have-build-in-function-hasownproperty

I updated the test so that is fails before the change and passes afterwards.  If you would like to see the error that was being produced, you can run the new version of the tests with the old .config file in place. 
